### PR TITLE
Address clippy warnings

### DIFF
--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -18,7 +18,12 @@
     html_root_url = "https://docs.rs/tendermint/0.10.0"
 )]
 
+// NOTE(EB): can't figure out how to easily remove the extern crate per Rust2018 upgrade ...
+#[allow(unused_extern_crates)]
 extern crate prost_amino as prost;
+
+// NOTE(EB): can't figure out how to easily remove the extern crate per Rust2018 upgrade ...
+#[allow(unused_extern_crates)]
 #[macro_use]
 extern crate prost_amino_derive as prost_derive;
 

--- a/tendermint/tests/config.rs
+++ b/tendermint/tests/config.rs
@@ -118,8 +118,8 @@ mod files {
         assert_eq!(p2p.max_num_outbound_peers, 10);
         assert_eq!(*p2p.flush_throttle_timeout, Duration::from_millis(100));
         assert_eq!(p2p.max_packet_msg_payload_size, 1024);
-        assert_eq!(p2p.send_rate.bytes_per_sec(), 5120000);
-        assert_eq!(p2p.recv_rate.bytes_per_sec(), 5120000);
+        assert_eq!(p2p.send_rate.bytes_per_sec(), 5_120_000);
+        assert_eq!(p2p.recv_rate.bytes_per_sec(), 5_120_000);
         assert!(p2p.pex);
         assert!(!p2p.seed_mode);
         assert_eq!(p2p.private_peer_ids.len(), 3);
@@ -152,7 +152,7 @@ mod files {
         assert!(mempool.broadcast);
         assert_eq!(mempool.wal_dir, None);
         assert_eq!(mempool.size, 5000);
-        assert_eq!(mempool.max_txs_bytes, 1073741824);
+        assert_eq!(mempool.max_txs_bytes, 1_073_741_824);
         assert_eq!(mempool.cache_size, 10000);
 
         // consensus configuration options

--- a/tendermint/tests/config.rs
+++ b/tendermint/tests/config.rs
@@ -12,6 +12,7 @@ mod files {
     }
 
     /// Parse an example `config.toml` file to a `TendermintConfig` struct
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn config_toml_parser() {
         let config_toml = read_fixture("config.toml");

--- a/tendermint/tests/rpc.rs
+++ b/tendermint/tests/rpc.rs
@@ -20,7 +20,7 @@ mod endpoints {
             .response;
 
         assert_eq!(response.data.as_str(), EXAMPLE_APP);
-        assert_eq!(response.last_block_height.value(), 488120);
+        assert_eq!(response.last_block_height.value(), 488_120);
     }
 
     #[test]
@@ -62,8 +62,8 @@ mod endpoints {
 
         let tendermint::abci::Responses {
             deliver_tx,
-            begin_block: _,
             end_block,
+            ..
         } = response.results;
 
         let log_json = &deliver_tx[0].log.as_ref().unwrap().parse_json().unwrap();
@@ -72,8 +72,8 @@ mod endpoints {
         assert_eq!(log_json_value["msg_index"].as_str().unwrap(), "0");
         assert_eq!(log_json_value["success"].as_bool().unwrap(), true);
 
-        assert_eq!(deliver_tx[0].gas_wanted.value(), 200000);
-        assert_eq!(deliver_tx[0].gas_used.value(), 105662);
+        assert_eq!(deliver_tx[0].gas_wanted.value(), 200_000);
+        assert_eq!(deliver_tx[0].gas_used.value(), 105_662);
 
         let tag = deliver_tx[0]
             .tags
@@ -87,7 +87,7 @@ mod endpoints {
         );
 
         let validator_update = &end_block.as_ref().unwrap().validator_updates[0];
-        assert_eq!(validator_update.power.value(), 1233243);
+        assert_eq!(validator_update.power.value(), 1_233_243);
     }
 
     #[test]
@@ -95,7 +95,7 @@ mod endpoints {
         let response =
             endpoint::blockchain::Response::from_json(&read_json_fixture("blockchain")).unwrap();
 
-        assert_eq!(response.last_height.value(), 488556);
+        assert_eq!(response.last_height.value(), 488_556);
         assert_eq!(response.block_metas.len(), 10);
 
         let block_meta = &response.block_metas[0];
@@ -183,7 +183,7 @@ mod endpoints {
         } = response.genesis;
 
         assert_eq!(chain_id.as_str(), EXAMPLE_CHAIN);
-        assert_eq!(consensus_params.block.max_bytes, 200000);
+        assert_eq!(consensus_params.block.max_bytes, 200_000);
     }
 
     #[test]
@@ -205,7 +205,7 @@ mod endpoints {
         let response = endpoint::status::Response::from_json(&read_json_fixture("status")).unwrap();
 
         assert_eq!(response.node_info.network.as_str(), EXAMPLE_CHAIN);
-        assert_eq!(response.sync_info.latest_block_height.value(), 410744);
+        assert_eq!(response.sync_info.latest_block_height.value(), 410_744);
         assert_eq!(response.validator_info.voting_power.value(), 0);
     }
 


### PR DESCRIPTION
I couldn't figure out how to remove the `extern crate` with the rename here. I read https://doc.rust-lang.org/nightly/edition-guide/rust-2018/module-system/path-clarity.html#renaming-crates, but couldn't get it working. Possibly it's because I needed to edit *alot* more files, but didn't feel I should have to do that. So I also tried https://doc.rust-lang.org/1.28.0/cargo/reference/unstable.html#rename-dependency, but couldn't get it working either. So I just turned off the lint in one spot ...

Also the `config_toml_parser` could be broken out a bit but didn't seem like a big deal to just disable the lint for now.