### PR TITLE
Change type of ``max_gas`` to i64, and remove two clones.

### DIFF
--- a/tendermint/src/abci/transaction.rs
+++ b/tendermint/src/abci/transaction.rs
@@ -25,7 +25,7 @@ impl Transaction {
 
     /// Convert this transaction into a byte vector
     pub fn into_vec(self) -> Vec<u8> {
-        self.0.clone()
+        self.0
     }
 
     /// Borrow the contents of this transaction as a byte slice
@@ -79,7 +79,7 @@ impl Data {
 
     /// Convert this collection into a vector
     pub fn into_vec(self) -> Vec<Transaction> {
-        self.iter().cloned().collect()
+        self.txs.unwrap_or_default()
     }
 
     /// Iterate over the transactions in the collection

--- a/tendermint/src/block/size.rs
+++ b/tendermint/src/block/size.rs
@@ -17,10 +17,10 @@ pub struct Size {
 
     /// Maximum amount of gas which can be spent on a block
     #[serde(
-        serialize_with = "serializers::serialize_u64",
-        deserialize_with = "serializers::parse_u64"
+        serialize_with = "serializers::serialize_i64",
+        deserialize_with = "serializers::parse_i64"
     )]
-    pub max_gas: u64,
+    pub max_gas: i64,
 
     /// Time iota in ms
     #[serde(


### PR DESCRIPTION
I'm not sure about the specification of ``max_gas``, but the default ``genesis.conf`` generated by ``tendermint`` has ``max_gas`` set to ``-1``, so.