### PR TITLE
Implement ``Default`` trait for tendermint data types

### DIFF
--- a/tendermint/src/abci/code.rs
+++ b/tendermint/src/abci/code.rs
@@ -18,6 +18,12 @@ pub enum Code {
     Err(u32),
 }
 
+impl Default for Code {
+    fn default() -> Code {
+        Code::Ok
+    }
+}
+
 impl Code {
     /// Was the response OK?
     pub fn is_ok(self) -> bool {

--- a/tendermint/src/abci/data.rs
+++ b/tendermint/src/abci/data.rs
@@ -10,7 +10,7 @@ use subtle_encoding::hex;
 ///
 /// Transactions are opaque binary blobs which are validated according to
 /// application-specific rules.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct Data(Vec<u8>);
 
 impl Data {

--- a/tendermint/src/abci/log.rs
+++ b/tendermint/src/abci/log.rs
@@ -13,6 +13,12 @@ impl Log {
     }
 }
 
+impl From<&str> for Log {
+    fn from(s: &str) -> Self {
+        Log(s.to_owned())
+    }
+}
+
 impl AsRef<str> for Log {
     fn as_ref(&self) -> &str {
         self.0.as_ref()

--- a/tendermint/src/abci/log.rs
+++ b/tendermint/src/abci/log.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
 /// ABCI log data
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
 pub struct Log(String);
 
 impl Log {

--- a/tendermint/src/abci/transaction.rs
+++ b/tendermint/src/abci/transaction.rs
@@ -61,7 +61,7 @@ impl Serialize for Transaction {
 /// transactions are arbitrary byte arrays.
 ///
 /// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#data>
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct Data {
     txs: Option<Vec<Transaction>>,
 }

--- a/tendermint/src/abci/transaction/hash.rs
+++ b/tendermint/src/abci/transaction/hash.rs
@@ -28,6 +28,12 @@ impl Hash {
     }
 }
 
+impl Default for Hash {
+    fn default() -> Hash {
+        Hash([0; LENGTH])
+    }
+}
+
 impl AsRef<[u8]> for Hash {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -15,7 +15,7 @@ use subtle_encoding::hex;
 const LENGTH: usize = 20;
 
 /// Account IDs
-#[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord, Default)]
 pub struct Id([u8; LENGTH]);
 
 impl Id {

--- a/tendermint/src/block.rs
+++ b/tendermint/src/block.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// evidence of malfeasance (i.e. signing conflicting votes).
 ///
 /// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#block>
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct Block {
     /// Block header
     pub header: Header,

--- a/tendermint/src/block/commit.rs
+++ b/tendermint/src/block/commit.rs
@@ -8,7 +8,7 @@ use std::{ops::Deref, slice};
 ///
 /// <https://github.com/tendermint/tendermint/blob/51dc810d041eaac78320adc6d53ad8b160b06601/types/block.go#L486-L502>
 /// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#lastcommit>
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Commit {
     /// Block ID of the last commit
     pub block_id: block::Id,
@@ -18,7 +18,7 @@ pub struct Commit {
 }
 
 /// Precommits which certify that a block is valid
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Precommits(Option<Vec<Option<Vote>>>);
 
 impl Precommits {

--- a/tendermint/src/block/header.rs
+++ b/tendermint/src/block/header.rs
@@ -11,7 +11,7 @@ use {
 /// previous block, and the results returned by the application.
 ///
 /// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#header>
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Header {
     /// Header version
     pub version: Version,
@@ -74,7 +74,7 @@ pub struct Header {
 /// application.
 ///
 /// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#version>
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Version {
     /// Block version
     #[serde(

--- a/tendermint/src/block/id.rs
+++ b/tendermint/src/block/id.rs
@@ -16,7 +16,7 @@ pub const PREFIX_LENGTH: usize = 10;
 /// as well as the number of parts in the block.
 ///
 /// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#blockid>
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord, Default)]
 pub struct Id {
     /// The block's main hash is the Merkle root of all the fields in the
     /// block header.

--- a/tendermint/src/chain/id.rs
+++ b/tendermint/src/chain/id.rs
@@ -18,6 +18,13 @@ pub const MAX_LENGTH: usize = 50;
 #[derive(Copy, Clone)]
 pub struct Id([u8; MAX_LENGTH]);
 
+impl Default for Id {
+    fn default() -> Id {
+        static DUMMY_BYTES: [u8; MAX_LENGTH] = [0; MAX_LENGTH];
+        Id(DUMMY_BYTES)
+    }
+}
+
 impl Id {
     /// Get the chain ID as a `str`
     pub fn as_str(&self) -> &str {

--- a/tendermint/src/channel.rs
+++ b/tendermint/src/channel.rs
@@ -48,7 +48,7 @@ pub struct Channel {
 }
 
 /// Channel collections
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
 pub struct Channels(String);
 
 impl Display for Channels {

--- a/tendermint/src/evidence.rs
+++ b/tendermint/src/evidence.rs
@@ -51,7 +51,7 @@ impl Serialize for Evidence {
 /// Evidence data is a wrapper for a list of `Evidence`.
 ///
 /// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#evidencedata>
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct Data {
     evidence: Option<Vec<Evidence>>,
 }

--- a/tendermint/src/hash.rs
+++ b/tendermint/src/hash.rs
@@ -28,6 +28,12 @@ pub enum Hash {
     Null,
 }
 
+impl Default for Hash {
+    fn default() -> Hash {
+        Hash::Null
+    }
+}
+
 impl Hash {
     #[allow(clippy::new_ret_no_self)]
     /// Create a new `Hash` with the given algorithm type

--- a/tendermint/src/moniker.rs
+++ b/tendermint/src/moniker.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 /// Validator display names
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Default)]
 pub struct Moniker(String);
 
 impl FromStr for Moniker {

--- a/tendermint/src/net.rs
+++ b/tendermint/src/net.rs
@@ -39,6 +39,16 @@ pub enum Address {
     },
 }
 
+impl Default for Address {
+    fn default() -> Address {
+        Address::Tcp {
+            peer_id: None,
+            host: "127.0.0.1".to_owned(),
+            port: 0,
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for Address {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Self::from_str(&String::deserialize(deserializer)?)

--- a/tendermint/src/node/id.rs
+++ b/tendermint/src/node/id.rs
@@ -16,7 +16,7 @@ pub const LENGTH: usize = 20;
 
 /// Node IDs
 #[allow(clippy::derive_hash_xor_eq)]
-#[derive(Copy, Clone, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct Id([u8; LENGTH]);
 
 impl Id {

--- a/tendermint/src/node/info.rs
+++ b/tendermint/src/node/info.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
 /// Node information
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
 pub struct Info {
     /// Protocol version information
     pub protocol_version: ProtocolVersionInfo,
@@ -33,7 +33,7 @@ pub struct Info {
 }
 
 /// Protocol version information
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
 pub struct ProtocolVersionInfo {
     /// P2P protocol version
     #[serde(
@@ -58,7 +58,7 @@ pub struct ProtocolVersionInfo {
 }
 
 /// Listen address information
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
 pub struct ListenAddress(String);
 
 impl ListenAddress {
@@ -80,7 +80,7 @@ impl Display for ListenAddress {
 }
 
 /// Other information
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
 pub struct OtherInfo {
     /// TX index status
     pub tx_index: TxIndexStatus,
@@ -99,6 +99,12 @@ pub enum TxIndexStatus {
     /// Index is off
     #[serde(rename = "off")]
     Off,
+}
+
+impl Default for TxIndexStatus {
+    fn default() -> TxIndexStatus {
+        TxIndexStatus::On
+    }
 }
 
 impl From<TxIndexStatus> for bool {

--- a/tendermint/src/public_key.rs
+++ b/tendermint/src/public_key.rs
@@ -91,6 +91,13 @@ impl PublicKey {
     }
 }
 
+impl Default for PublicKey {
+    fn default() -> PublicKey {
+        static DUMMY_BYTES: [u8; 32] = [0; 32];
+        PublicKey::Ed25519(ed25519::PublicKey::new(DUMMY_BYTES))
+    }
+}
+
 impl From<ed25519::PublicKey> for PublicKey {
     fn from(pk: ed25519::PublicKey) -> PublicKey {
         PublicKey::Ed25519(pk)

--- a/tendermint/src/rpc/endpoint/abci_query.rs
+++ b/tendermint/src/rpc/endpoint/abci_query.rs
@@ -55,7 +55,7 @@ pub struct Response {
 impl rpc::Response for Response {}
 
 /// ABCI query results
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct AbciQuery {
     /// Response code
     pub code: Code,

--- a/tendermint/src/rpc/endpoint/broadcast/tx_sync.rs
+++ b/tendermint/src/rpc/endpoint/broadcast/tx_sync.rs
@@ -29,7 +29,7 @@ impl rpc::Request for Request {
 }
 
 /// Response from either an async or sync transaction broadcast request.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct Response {
     /// Code
     pub code: Code,

--- a/tendermint/src/rpc/endpoint/status.rs
+++ b/tendermint/src/rpc/endpoint/status.rs
@@ -16,7 +16,7 @@ impl rpc::Request for Request {
 }
 
 /// Status responses
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct Response {
     /// Node information
     pub node_info: node::Info,
@@ -31,7 +31,7 @@ pub struct Response {
 impl rpc::Response for Response {}
 
 /// Sync information
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct SyncInfo {
     /// Latest block hash
     pub latest_block_hash: Hash,

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -43,6 +43,12 @@ impl Time {
     }
 }
 
+impl Default for Time {
+    fn default() -> Time {
+        Time::unix_epoch()
+    }
+}
+
 impl From<DateTime<Utc>> for Time {
     fn from(t: DateTime<Utc>) -> Time {
         Time(t)

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -3,6 +3,8 @@
 use crate::error::{Error, ErrorKind};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tai64::TAI64N;
 
@@ -36,6 +38,11 @@ impl Time {
         Ok(Time(DateTime::parse_from_rfc3339(s)?.with_timezone(&Utc)))
     }
 
+    /// Returns an RFC 3339 string, such as 1996-12-19T16:39:57-08:00.
+    pub fn to_rfc3339(&self) -> String {
+        self.0.to_rfc3339()
+    }
+
     /// Convert this timestamp to a `SystemTime`
     pub fn to_system_time(&self) -> Result<SystemTime, Error> {
         let duration_since_epoch = self.duration_since(Self::unix_epoch())?;
@@ -46,6 +53,20 @@ impl Time {
 impl Default for Time {
     fn default() -> Time {
         Time::unix_epoch()
+    }
+}
+
+impl fmt::Display for Time {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.to_rfc3339())
+    }
+}
+
+impl FromStr for Time {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Time::parse_from_rfc3339(s)
     }
 }
 

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -37,7 +37,7 @@ impl Set {
 }
 
 /// Validator information
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct Info {
     /// Validator account address
     pub address: account::Id,

--- a/tendermint/src/version.rs
+++ b/tendermint/src/version.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
 /// Tendermint version
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub struct Version(String);
 
 impl Display for Version {

--- a/tendermint/src/vote/power.rs
+++ b/tendermint/src/vote/power.rs
@@ -3,7 +3,7 @@
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Voting power
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Default)]
 pub struct Power(u64);
 
 impl Power {


### PR DESCRIPTION
Implements ``Default`` trait for tendermint data types, useful for writing tests.
It also implements several utility traits.