### PR TITLE
Parse validators field in genesis api

### DIFF
--- a/tendermint/src/genesis.rs
+++ b/tendermint/src/genesis.rs
@@ -1,6 +1,6 @@
 //! Genesis data
 
-use crate::{chain, consensus, Hash, Time};
+use crate::{chain, consensus, validator, Hash, Time};
 use serde::{Deserialize, Serialize};
 
 /// Genesis data
@@ -14,6 +14,9 @@ pub struct Genesis<AppState = serde_json::Value> {
 
     /// Consensus parameters
     pub consensus_params: consensus::Params,
+
+    /// Validators
+    pub validators: Vec<validator::Info>,
 
     /// App hash
     pub app_hash: Hash,

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -46,6 +46,7 @@ pub struct Info {
     pub pub_key: PublicKey,
 
     /// Validator voting power
+    #[serde(alias = "power")]
     pub voting_power: vote::Power,
 
     /// Validator proposer priority

--- a/tendermint/tests/support/rpc/genesis.json
+++ b/tendermint/tests/support/rpc/genesis.json
@@ -20,6 +20,17 @@
           ]
         }
       },
+      "validators": [
+        {
+          "address": "B00A6323737F321EB0B8D59C6FD497A14B60938A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "cOQZvh/h9ZioSeUMZB/1Vy1Xo5x2sjrVjlE/qHnYifM="
+          },
+          "power": "9328525",
+          "name": "Certus One"
+        }
+      ],
       "app_hash": "",
       "app_state": {
         "accounts": [


### PR DESCRIPTION
`genesis` endpoint response has a `validators` field, which is similar to the one from `validators` endpoint, we can re-use the data type for this, only difference is the field name of `voting_power` becomes `power`.