### PR TITLE
Signing bytes need to encoded with encode_length_delimited

### DIFF
--- a/tendermint/src/amino_types/message.rs
+++ b/tendermint/src/amino_types/message.rs
@@ -1,3 +1,6 @@
+use prost_amino::encoding::encoded_len_varint;
+use std::convert::TryInto;
+
 /// Extend the original prost::Message trait with a few helper functions in order to
 /// reduce boiler-plate code (and without modifying the prost-amino dependency).
 pub trait AminoMessage: prost_amino::Message {
@@ -13,6 +16,21 @@ pub trait AminoMessage: prost_amino::Message {
     {
         let mut res = Vec::with_capacity(self.encoded_len());
         self.encode(&mut res).unwrap();
+        res
+    }
+
+    /// Encode prost-amino message as length delimited.
+    ///
+    /// Warning: Only use this method, if you are in control what will be encoded.
+    /// If there is an encoding error, this method will panic.
+    fn bytes_vec_length_delimited(&self) -> Vec<u8>
+    where
+        Self: Sized,
+    {
+        let len = self.encoded_len();
+        let mut res =
+            Vec::with_capacity(len + encoded_len_varint(len.try_into().expect("length overflow")));
+        self.encode_length_delimited(&mut res).unwrap();
         res
     }
 }

--- a/tendermint/src/vote.rs
+++ b/tendermint/src/vote.rs
@@ -101,7 +101,7 @@ impl lite::Vote for SignedVote {
     }
 
     fn sign_bytes(&self) -> Vec<u8> {
-        AminoMessage::bytes_vec(&self.vote.to_owned())
+        self.vote.bytes_vec_length_delimited()
     }
     fn signature(&self) -> &[u8] {
         match &self.signature {


### PR DESCRIPTION
So we have identical signing bytes as golang version to verify signatures.