### PR TITLE
Replace `rand_os` with `getrandom` (closes #23)

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -35,11 +35,11 @@ bytes = "0.4"
 bytes_0_5 = { version = "0.5", package = "bytes" }
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1"
+getrandom = "0.1"
 http = "0.2"
 hyper = "0.13"
 prost-amino = { version = "0.4.0" }
 prost-amino-derive = { version = "0.4.0" }
-rand_os = { version = "0.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 signatory = { version = "0.17", features = ["ed25519", "ecdsa"] }

--- a/tendermint/src/rpc/id.rs
+++ b/tendermint/src/rpc/id.rs
@@ -1,6 +1,6 @@
 //! JSONRPC IDs
 
-use rand_os::{rand_core::RngCore, OsRng};
+use getrandom::getrandom;
 use serde::{Deserialize, Serialize};
 
 /// JSONRPC ID: request-specific identifier
@@ -10,9 +10,8 @@ pub struct Id(String);
 impl Id {
     /// Create a JSONRPC ID containing a UUID v4 (i.e. random)
     pub fn uuid_v4() -> Self {
-        let mut rng = OsRng::new().unwrap();
         let mut bytes = [0; 16];
-        rng.fill_bytes(&mut bytes);
+        getrandom(&mut bytes).expect("RNG failure!");
 
         let uuid = uuid::Builder::from_bytes(bytes)
             .set_variant(uuid::Variant::RFC4122)


### PR DESCRIPTION
`rand_os` is just a wrapper for `getrandom`. I believe the long-term plan is to deprecrate it entirely.