### PR TITLE
Add verify_new_header

### DIFF
--- a/tendermint/src/block/signed_header.rs
+++ b/tendermint/src/block/signed_header.rs
@@ -4,7 +4,7 @@
 use crate::{
     block, hash, lite,
     lite::types::Validator,
-    lite::{Error, ValidatorSet},
+    lite::{ValidatorSet, VerifyError},
     vote::SignedVote,
 };
 use serde::{Deserialize, Serialize};
@@ -58,7 +58,7 @@ impl lite::Commit for SignedHeader {
         self.commit.block_id.hash
     }
 
-    fn voting_power_in<V>(&self, validators: &V) -> Result<u64, Error>
+    fn voting_power_in<V>(&self, validators: &V) -> Result<u64, VerifyError>
     where
         V: ValidatorSet,
     {
@@ -86,7 +86,7 @@ impl lite::Commit for SignedHeader {
             let sign_bytes = vote.sign_bytes();
 
             if !val.verify_signature(&sign_bytes, vote.signature()) {
-                return Err(Error::InvalidSignature);
+                return Err(VerifyError::InvalidSignature);
             }
             signed_power += val.power();
         }

--- a/tendermint/src/lite/verifier.rs
+++ b/tendermint/src/lite/verifier.rs
@@ -8,34 +8,40 @@
 //! // looks using the types and methods in this crate/module.
 //!```
 
-use crate::lite::{Commit, Error, Header, SignedHeader, TrustThreshold, ValidatorSet};
+use crate::lite::{
+    Commit, Header, SignedHeader, TrustThreshold, TrustedState, ValidatorSet, VerifyError,
+};
 use std::time::{Duration, SystemTime};
 
 /// Returns an error if the header has expired according to the given
 /// trusting_period and current time. If so, the verifier must be reset subjectively.
-pub fn expired<H>(last_header: &H, trusting_period: Duration, now: SystemTime) -> Result<(), Error>
+pub fn expired<H>(
+    last_header: &H,
+    trusting_period: Duration,
+    now: SystemTime,
+) -> Result<(), VerifyError>
 where
     H: Header,
 {
     match now.duration_since(last_header.bft_time().into()) {
         Ok(passed) => {
             if passed > trusting_period {
-                return Err(Error::Expired);
+                return Err(VerifyError::Expired);
             }
             Ok(())
         }
-        Err(_) => Err(Error::DurationOutOfRange),
+        Err(_) => Err(VerifyError::DurationOutOfRange),
     }
 }
 
-fn validate_next_vals<H, V>(header: H, next_vals: &V) -> Result<(), Error>
+fn validate_next_vals<H, V>(header: &H, next_vals: &V) -> Result<(), VerifyError>
 where
     H: Header,
     V: ValidatorSet,
 {
     // ensure the next validators in the header matches what was supplied.
     if header.next_validators_hash() != next_vals.hash() {
-        return Err(Error::InvalidNextValidatorSet);
+        return Err(VerifyError::InvalidNextValidatorSet);
     }
 
     Ok(())
@@ -44,35 +50,35 @@ where
 /// Captures the skipping condition, i.e., it defines when we can trust the header
 /// h2 based on header h1.
 /// Note that h1 and h2 have already passed basic validation by calling  `verify`.
-/// `Error::InsufficientVotingPower`is returned when there is not enough intersection
+/// `VerifyError::InsufficientVotingPower`is returned when there is not enough intersection
 /// between validator sets to have skipping condition true.
-pub fn check_support<S, V, L>(
-    h1: &S,
+pub fn check_support<H, S, V, L>(
+    h1: &H,
     h1_next_vals: &V,
     h2: &S,
     trust_threshold: L,
     trusting_period: Duration,
     now: SystemTime,
-) -> Result<(), Error>
+) -> Result<(), VerifyError>
 where
+    H: Header,
     S: SignedHeader,
     V: ValidatorSet,
     L: TrustThreshold,
 {
-    if let Err(err) = expired(h1.header(), trusting_period, now) {
-        return Err(err);
+    if h2.header().height() == h1.height().increment() {
+        if h2.header().validators_hash() != h1_next_vals.hash() {
+            return Err(VerifyError::InvalidNextValidatorSet);
+        }
+    } else {
+        expired(h1, trusting_period, now)?;
     }
 
-    if h2.header().height() == h1.header().height().increment()
-        && h2.header().validators_hash() != h1_next_vals.hash()
-    {
-        return Err(Error::InvalidNextValidatorSet);
-    }
     verify_commit_trusting(h1_next_vals, h2.commit(), trust_threshold)
 }
 
 /// Validate the validators and commit against the header.
-fn validate_vals_and_commit<H, V, C>(header: &H, commit: &C, vals: &V) -> Result<(), Error>
+fn validate_vals_and_commit<H, V, C>(header: &H, commit: &C, vals: &V) -> Result<(), VerifyError>
 where
     H: Header,
     V: ValidatorSet,
@@ -80,19 +86,19 @@ where
 {
     // ensure the validators in the header matches what we expect from our state.
     if header.validators_hash() != vals.hash() {
-        return Err(Error::InvalidValidatorSet);
+        return Err(VerifyError::InvalidValidatorSet);
     }
 
     // ensure the commit matches the header.
     if header.hash() != commit.header_hash() {
-        return Err(Error::InvalidCommitValue);
+        return Err(VerifyError::InvalidCommitValue);
     }
 
     Ok(())
 }
 
 /// Verify the commit is valid from the given validators for the header.
-pub fn verify<SH, V>(signed_header: &SH, validators: &V) -> Result<(), Error>
+pub fn verify<SH, V>(signed_header: &SH, validators: &V) -> Result<(), VerifyError>
 where
     SH: SignedHeader,
     V: ValidatorSet,
@@ -109,21 +115,21 @@ where
 
 /// Verify that +2/3 of the correct validator set signed this commit.
 /// NOTE: these validators are expected to be the correct validators for the commit.
-fn verify_commit_full<V, C>(vals: &V, commit: &C) -> Result<(), Error>
+fn verify_commit_full<V, C>(vals: &V, commit: &C) -> Result<(), VerifyError>
 where
     V: ValidatorSet,
     C: Commit,
 {
     let total_power = vals.total_power();
     if vals.len() != commit.votes_len() {
-        return Err(Error::InvalidCommitLength);
+        return Err(VerifyError::InvalidCommitLength);
     }
 
     let signed_power = commit.voting_power_in(vals)?;
 
     // check the signers account for +2/3 of the voting power
     if signed_power * 3 <= total_power * 2 {
-        return Err(Error::InsufficientVotingPower);
+        return Err(VerifyError::InsufficientVotingPower);
     }
 
     Ok(())
@@ -137,7 +143,7 @@ pub fn verify_commit_trusting<V, C, L>(
     validators: &V,
     commit: &C,
     trust_level: L,
-) -> Result<(), Error>
+) -> Result<(), VerifyError>
 where
     V: ValidatorSet,
     C: Commit,
@@ -149,8 +155,42 @@ where
     // check the signers account for +1/3 of the voting power (or more if the
     // trust_level requires so)
     if !trust_level.is_enough_power(signed_power, total_power) {
-        return Err(Error::InsufficientVotingPower);
+        return Err(VerifyError::InsufficientVotingPower);
     }
 
     Ok(())
+}
+
+/// Verify new incoming signed header against current trusted state,
+/// and return new state when success.
+pub fn verify_new_header<H, V, SH, S, L>(
+    state: &S,
+    signed_header: &SH,
+    next_vals: &V,
+    trust_threshold: L,
+    trusting_period: Duration,
+    now: SystemTime,
+) -> Result<S, VerifyError>
+where
+    H: Header + Clone,
+    V: ValidatorSet + Clone,
+    SH: SignedHeader<Header = H>,
+    S: TrustedState<Header = H, ValidatorSet = V>,
+    L: TrustThreshold,
+{
+    if let Some(header) = state.last_header() {
+        check_support(
+            header,
+            state.validators(),
+            signed_header,
+            trust_threshold,
+            trusting_period,
+            now,
+        )?;
+    }
+    validate_next_vals(signed_header.header(), next_vals)?;
+    Ok(S::new(
+        Some(signed_header.header().clone()),
+        next_vals.clone(),
+    ))
 }

--- a/tendermint/tests/lite.rs
+++ b/tendermint/tests/lite.rs
@@ -88,12 +88,12 @@ fn run_test_cases(cases: TestCases) {
             // the previous iteration of this loop. In both cases it is assumed that h1 was already
             // verified.
             let h2_verif_res = lite::verify(new_signed_header, new_vals);
-            let mut check_support_res: Result<(), lite::Error> = Ok(());
+            let mut check_support_res: Result<(), lite::VerifyError> = Ok(());
             if h2_verif_res.is_ok() {
                 check_support_res = lite::check_support(
-                    trusted_signed_header,
+                    &trusted_signed_header.header,
                     &trusted_next_vals,
-                    &new_signed_header,
+                    new_signed_header,
                     DefaultTrustLevel {},
                     trusting_period,
                     now.into(),


### PR DESCRIPTION
Add `verify_new_header` to combine the verifications of lite client logic when syncing new header.
Changed `TrustedState` to trait.