### PR TITLE
MockHeader and test_is_within_trust_period

### DIFF
--- a/tendermint/src/lite/types.rs
+++ b/tendermint/src/lite/types.rs
@@ -1,14 +1,6 @@
 //! All traits that are necessary and need to be implemented to use the main
 //! verification logic in `super::verifier` for a light client.
 
-// TODO can we abstract this away and use a generic identifier instead ?
-// Ie. something that just implements Eq ?
-// (Ismail): a really easy solution would be have a trait that expects an
-// as_bytes(&self) -> &[u8] method. It's unlikely that a hash won't be
-// representable as bytes, or an Id (that is basically also a hash)
-// but this feels a a bit like cheating
-use crate::account::Id;
-
 use crate::block::Height;
 use crate::Hash;
 
@@ -65,16 +57,11 @@ pub trait Header: Debug {
 /// It also provides a lookup method to fetch a validator by
 /// its identifier.
 pub trait ValidatorSet {
-    type Validator: Validator;
-
     /// Hash of the validator set.
     fn hash(&self) -> Hash;
 
     /// Total voting power of the set
     fn total_power(&self) -> u64;
-
-    /// Fetch validator via their ID (ie. their address).
-    fn validator(&self, val_id: Id) -> Option<Self::Validator>;
 
     /// Return the number of validators in this validator set.
     fn len(&self) -> usize;
@@ -83,18 +70,12 @@ pub trait ValidatorSet {
     fn is_empty(&self) -> bool;
 }
 
-/// Validator has a voting power and can verify
-/// its own signatures. Note it must have implicit access
-/// to its public key material to verify signatures.
-pub trait Validator {
-    fn power(&self) -> u64;
-    fn verify_signature(&self, sign_bytes: &[u8], signature: &[u8]) -> bool;
-}
-
 /// Commit is proof a Header is valid.
 /// It has an underlying Vote type with the relevant vote data
 /// for verification.
 pub trait Commit {
+    type ValidatorSet: ValidatorSet;
+
     /// Hash of the header this commit is for.
     fn header_hash(&self) -> Hash;
 
@@ -104,9 +85,7 @@ pub trait Commit {
     ///
     /// This method corresponds to the (pure) auxiliary function int the spec:
     /// `votingpower_in(signers(h.Commit),h.Header.V)`.
-    fn voting_power_in<V>(&self, vals: &V) -> Result<u64, Error>
-    where
-        V: ValidatorSet;
+    fn voting_power_in(&self, vals: &Self::ValidatorSet) -> Result<u64, Error>;
 
     /// Return the number of votes included in this commit
     /// (including nil/empty votes).

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -26,9 +26,17 @@ impl Set {
     }
 }
 
-impl lite::ValidatorSet for Set {
-    type Validator = Info;
+impl Set {
+    /// Returns the validator with the given Id if its in the Set.
+    pub fn validator(&self, val_id: account::Id) -> Option<Info> {
+        self.validators
+            .iter()
+            .find(|val| val.address == val_id)
+            .cloned()
+    }
+}
 
+impl lite::ValidatorSet for Set {
     /// Compute the Merkle root of the validator set
     fn hash(&self) -> Hash {
         let validator_bytes: Vec<Vec<u8>> = self
@@ -43,13 +51,6 @@ impl lite::ValidatorSet for Set {
         self.validators.iter().fold(0u64, |total, val_info| {
             total + val_info.voting_power.value()
         })
-    }
-
-    fn validator(&self, val_id: account::Id) -> Option<Self::Validator> {
-        self.validators
-            .iter()
-            .find(|val| val.address == val_id)
-            .cloned()
     }
 
     fn len(&self) -> usize {
@@ -87,12 +88,15 @@ pub struct Info {
     pub proposer_priority: Option<ProposerPriority>,
 }
 
-impl lite::Validator for Info {
-    fn power(&self) -> u64 {
+impl Info {
+    /// Return the voting power of the validator.
+    pub fn power(&self) -> u64 {
         self.voting_power.value()
     }
 
-    fn verify_signature(&self, sign_bytes: &[u8], signature: &[u8]) -> bool {
+    /// Verify the given signature against the given sign_bytes using the validators
+    /// public key.
+    pub fn verify_signature(&self, sign_bytes: &[u8], signature: &[u8]) -> bool {
         if let Some(pk) = &self.pub_key.ed25519() {
             let verifier = Ed25519Verifier::from(pk);
             if let Ok(sig) = ed25519::Signature::from_bytes(signature) {


### PR DESCRIPTION
Initial mock and test for the Header and `is_within_trust_period`.

I hesitated on mocking the Commit because it ultimately requires Validator, which has a `verify_signature` method, which I think we'd like to avoid needing to test this core logic (ie. https://github.com/interchainio/tendermint-rs/issues/96#issuecomment-569360555).

We should consider some more changes to the traits to eliminate the need for this. It will make mocking everything much easier! 

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
