### PR TITLE
remove Validator trait; make ValidatorSet associated to Commit

### DIFF
--- a/tendermint/src/lite/types.rs
+++ b/tendermint/src/lite/types.rs
@@ -1,13 +1,6 @@
 //! All traits that are necessary and need to be implemented to use the main
 //! verification logic in `super::verifier` for a light client.
 
-// TODO can we abstract this away and use a generic identifier instead ?
-// Ie. something that just implements Eq ?
-// (Ismail): a really easy solution would be have a trait that expects an
-// as_bytes(&self) -> &[u8] method. It's unlikely that a hash won't be
-// representable as bytes, or an Id (that is basically also a hash)
-// but this feels a a bit like cheating
-
 use crate::block::Height;
 use crate::Hash;
 

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -26,9 +26,17 @@ impl Set {
     }
 }
 
-impl lite::ValidatorSet for Set {
-    type Validator = Info;
+impl Set {
+    /// Returns the validator with the given Id if its in the Set.
+    pub fn validator(&self, val_id: account::Id) -> Option<Info> {
+        self.validators
+            .iter()
+            .find(|val| val.address == val_id)
+            .cloned()
+    }
+}
 
+impl lite::ValidatorSet for Set {
     /// Compute the Merkle root of the validator set
     fn hash(&self) -> Hash {
         let validator_bytes: Vec<Vec<u8>> = self
@@ -43,13 +51,6 @@ impl lite::ValidatorSet for Set {
         self.validators.iter().fold(0u64, |total, val_info| {
             total + val_info.voting_power.value()
         })
-    }
-
-    fn validator(&self, val_id: account::Id) -> Option<Self::Validator> {
-        self.validators
-            .iter()
-            .find(|val| val.address == val_id)
-            .cloned()
     }
 
     fn len(&self) -> usize {
@@ -87,12 +88,15 @@ pub struct Info {
     pub proposer_priority: Option<ProposerPriority>,
 }
 
-impl lite::Validator for Info {
-    fn power(&self) -> u64 {
+impl Info {
+    /// Return the voting power of the validator.
+    pub fn power(&self) -> u64 {
         self.voting_power.value()
     }
 
-    fn verify_signature(&self, sign_bytes: &[u8], signature: &[u8]) -> bool {
+    /// Verify the given signature against the given sign_bytes using the validators
+    /// public key.
+    pub fn verify_signature(&self, sign_bytes: &[u8], signature: &[u8]) -> bool {
         if let Some(pk) = &self.pub_key.ed25519() {
             let verifier = Ed25519Verifier::from(pk);
             if let Ok(sig) = ed25519::Signature::from_bytes(signature) {


### PR DESCRIPTION
As per #96, this removes the Validator trait by making ValidatorSet an associated type of Commit. As a bonus, we eliminate dependency on the `Id` type from the light module.

This allows implementations of Commit to access underlying functionality of a validator set (like its validators and signature verification with them) without requiring that functionality to be part of the light client module. This should also make it much easier to write tests for the module now, since we don't need to mock a `verify_signature`.

I'm not sure if this is the best way to do things, but it seems to be along the right lines ...

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
