### PR TITLE
Fix clippy errors

### DIFF
--- a/tendermint/src/block/commit.rs
+++ b/tendermint/src/block/commit.rs
@@ -32,7 +32,7 @@ impl Precommits {
 
     /// Convert this collection of precommits into a vector
     pub fn into_vec(self) -> Vec<Option<Vote>> {
-        self.0.clone()
+        self.0
     }
 
     /// Iterate over the precommits in the collection

--- a/tendermint/src/consensus/state.rs
+++ b/tendermint/src/consensus/state.rs
@@ -49,18 +49,14 @@ impl fmt::Display for State {
 
 impl Ord for State {
     fn cmp(&self, other: &State) -> Ordering {
-        if self.height < other.height {
-            Ordering::Less
-        } else if self.height == other.height {
-            if self.round < other.round {
-                Ordering::Less
-            } else if self.round == other.round {
-                self.step.cmp(&other.step)
-            } else {
-                Ordering::Greater
-            }
-        } else {
-            Ordering::Greater
+        match self.height.cmp(&other.height) {
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Less => Ordering::Less,
+            Ordering::Equal => match self.round.cmp(&other.round) {
+                Ordering::Greater => Ordering::Greater,
+                Ordering::Less => Ordering::Less,
+                Ordering::Equal => self.step.cmp(&other.step),
+            },
         }
     }
 }


### PR DESCRIPTION
New clippy errors since the latest rust stable release:


<details><summary>Expand circle log</summary>
<p>

```
error: redundant clone
  --> tendermint/src/block/commit.rs:35:15
   |
35 |         self.0.clone()
   |               ^^^^^^^^ help: remove this
   |
note: lint level defined here
  --> tendermint/src/lib.rs:8:5
   |
8  |     warnings,
   |     ^^^^^^^^
   = note: `#[deny(clippy::redundant_clone)]` implied by `#[deny(warnings)]`
note: this value is dropped without further use
  --> tendermint/src/block/commit.rs:35:9
   |
35 |         self.0.clone()
   |         ^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

error: `if` chain can be rewritten with `match`
  --> tendermint/src/consensus/state.rs:52:9
   |
52 | /         if self.height < other.height {
53 | |             Ordering::Less
54 | |         } else if self.height == other.height {
55 | |             if self.round < other.round {
...  |
63 | |             Ordering::Greater
64 | |         }
   | |_________^
   |
note: lint level defined here
  --> tendermint/src/lib.rs:8:5
   |
8  |     warnings,
   |     ^^^^^^^^
   = note: `#[deny(clippy::comparison_chain)]` implied by `#[deny(warnings)]`
   = help: Consider rewriting the `if` chain to use `cmp` and `match`.
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#comparison_chain

error: `if` chain can be rewritten with `match`
  --> tendermint/src/consensus/state.rs:55:13
   |
55 | /             if self.round < other.round {
56 | |                 Ordering::Less
57 | |             } else if self.round == other.round {
58 | |                 self.step.cmp(&other.step)
59 | |             } else {
60 | |                 Ordering::Greater
61 | |             }
   | |_____________^
   |
   = help: Consider rewriting the `if` chain to use `cmp` and `match`.
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#comparison_chain

error: redundant clone
  --> tendermint/src/block/commit.rs:35:15
   |
35 |         self.0.clone()
   |               ^^^^^^^^ help: remove this
   |
note: lint level defined here
  --> tendermint/src/lib.rs:8:5
   |
8  |     warnings,
   |     ^^^^^^^^
   = note: `#[deny(clippy::redundant_clone)]` implied by `#[deny(warnings)]`
note: this value is dropped without further use
  --> tendermint/src/block/commit.rs:35:9
   |
35 |         self.0.clone()
   |         ^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

error: `if` chain can be rewritten with `match`
  --> tendermint/src/consensus/state.rs:52:9
   |
52 | /         if self.height < other.height {
53 | |             Ordering::Less
54 | |         } else if self.height == other.height {
55 | |             if self.round < other.round {
...  |
63 | |             Ordering::Greater
64 | |         }
   | |_________^
   |
note: lint level defined here
  --> tendermint/src/lib.rs:8:5
   |
8  |     warnings,
   |     ^^^^^^^^
   = note: `#[deny(clippy::comparison_chain)]` implied by `#[deny(warnings)]`
   = help: Consider rewriting the `if` chain to use `cmp` and `match`.
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#comparison_chain

error: `if` chain can be rewritten with `match`
  --> tendermint/src/consensus/state.rs:55:13
   |
55 | /             if self.round < other.round {
56 | |                 Ordering::Less
57 | |             } else if self.round == other.round {
58 | |                 self.step.cmp(&other.step)
59 | |             } else {
60 | |                 Ordering::Greater
61 | |             }
   | |_____________^
   |
   = help: Consider rewriting the `if` chain to use `cmp` and `match`.
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#comparison_chain

error: aborting due to 3 previous errors

error: could not compile `tendermint`.

```

</p>
</details>
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
