### PR TITLE
Lite: complete test mocks and start some tests

### DIFF
--- a/tendermint/src/lite/public.rs
+++ b/tendermint/src/lite/public.rs
@@ -357,10 +357,7 @@ mod tests {
         let height = 1;
         let vals = &MockValSet::new(vals_vec.clone());
         let header = MockHeader::new(height, time, vals.hash(), vals.hash());
-        let commit = MockCommit::new(
-            header.hash(),
-            vals_vec.into_iter().map(|x| Some(x)).collect(),
-        );
+        let commit = MockCommit::new(header.hash(), vals_vec.into_iter().map(Some).collect());
         let sh = &MockSignedHeader::new(header, commit);
         MockState::new(sh, vals)
     }

--- a/tendermint/src/lite/public.rs
+++ b/tendermint/src/lite/public.rs
@@ -391,7 +391,7 @@ mod tests {
 
     static THRESHOLD: &MockThreshold = &MockThreshold {};
 
-    // convenience for validators that signed commit 
+    // convenience for validators that signed commit
     static S0: Option<usize> = Some(0);
     static S1: Option<usize> = Some(1);
     static S2: Option<usize> = Some(2);
@@ -416,7 +416,7 @@ mod tests {
     #[test]
     fn test_verify_single_skip_1_val_skip() {
         let ts = &init_state(vec![0]);
-        let err =  Error::InsufficientVotingPower;
+        let err = Error::InsufficientVotingPower;
 
         //*****
         // Ok
@@ -434,7 +434,7 @@ mod tests {
         assert_err(ts, vec![1], vec![S1], err);
 
         // 0% overlap - val set contains original signer, but they didn't sign
-        assert_err(ts,vec![0, 1, 2, 3],vec![None, S1, S2, S3],err);
+        assert_err(ts, vec![0, 1, 2, 3], vec![None, S1, S2, S3], err);
     }
 
     // test whether we can jump to a new header with valid data and commit,
@@ -462,7 +462,7 @@ mod tests {
         assert_err(ts, vec![2], vec![S2], err);
 
         // 0% overlap (original signer is still in val set but not in commit)
-        assert_err(ts,vec![0, 2, 3, 4],vec![None, S2, S3, S4],err);
+        assert_err(ts, vec![0, 2, 3, 4], vec![None, S2, S3, S4], err);
     }
 
     // test whether we can jump to a new header with valid data and commit,
@@ -485,7 +485,7 @@ mod tests {
 
         //*************
         // Err
-        
+
         // 33% overlap (one original signer still present)
         assert_err(ts, vec![0], vec![S0], err);
         assert_err(ts, vec![0, 3], vec![S0, S3], err);

--- a/tendermint/src/lite/types.rs
+++ b/tendermint/src/lite/types.rs
@@ -82,6 +82,12 @@ pub trait Commit {
     /// Compute the voting power of the validators that correctly signed the commit,
     /// according to their voting power in the passed in validator set.
     /// Will return an error in case an invalid signature was included.
+    /// TODO/XXX: This cannot detect if a signature from an incorrect validator 
+    /// is included. That's fine when we're just trying to see if we can skip,
+    /// but when actually verifying it means we might accept commits that have sigs from 
+    /// outside the correct validator set, which is something we expect to be able to detect
+    /// (it's not a real issue, but it would indicate a faulty full node).
+    ///
     ///
     /// This method corresponds to the (pure) auxiliary function in the spec:
     /// `votingpower_in(signers(h.Commit),h.Header.V)`.
@@ -155,6 +161,8 @@ pub enum Error {
     InvalidCommitValue, // commit is not for the header we expected
     InvalidCommitLength,
 
+    // TODO(EB): we need to differentiate when this is from
+    // skipping and when it's from verifying !
     InsufficientVotingPower, // TODO(Liamsi): change to same name as spec if this changes (curently ErrTooMuchChange)
 
     RequestFailed,

--- a/tendermint/src/lite/types.rs
+++ b/tendermint/src/lite/types.rs
@@ -82,9 +82,9 @@ pub trait Commit {
     /// Compute the voting power of the validators that correctly signed the commit,
     /// according to their voting power in the passed in validator set.
     /// Will return an error in case an invalid signature was included.
-    /// TODO/XXX: This cannot detect if a signature from an incorrect validator 
+    /// TODO/XXX: This cannot detect if a signature from an incorrect validator
     /// is included. That's fine when we're just trying to see if we can skip,
-    /// but when actually verifying it means we might accept commits that have sigs from 
+    /// but when actually verifying it means we might accept commits that have sigs from
     /// outside the correct validator set, which is something we expect to be able to detect
     /// (it's not a real issue, but it would indicate a faulty full node).
     ///
@@ -149,7 +149,8 @@ pub trait Store {
     fn get_smaller_or_equal(&self, h: Height) -> Result<Self::TrustedState, Error>;
 }
 
-#[derive(Debug, PartialEq)]
+// NOTE: Copy/Clone for convenience in testing ...
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Error {
     Expired,
     DurationOutOfRange,

--- a/tendermint/src/lite/verifier.rs
+++ b/tendermint/src/lite/verifier.rs
@@ -143,7 +143,9 @@ where
 }
 
 /// Verify that +2/3 of the correct validator set signed this commit.
-/// NOTE: these validators are expected to be the correct validators for the commit.
+/// NOTE: these validators are expected to be the correct validators for the commit,
+/// but since we're using voting_power_in, we can't actually detect if there's
+/// votes from validators not in the set.
 pub fn verify_commit_full<C>(vals: &C::ValidatorSet, commit: &C) -> Result<(), Error>
 where
     C: Commit,
@@ -153,6 +155,9 @@ where
 
     // check the signers account for +2/3 of the voting power
     if signed_power * 3 <= total_power * 2 {
+        // TODO(EB): Use a different error from
+        // verify_commit_trusting else bisection
+        // will happen when the commit is actually just invalid!
         return Err(Error::InsufficientVotingPower);
     }
 


### PR DESCRIPTION
First take at some tests for the new `verify_single` function, ala #113 

This completes an implementation of mocks for the core types for the lite module and shows how to use them for testing. Still unmocked are the `Store` and `Requester`.

There's probably much to be improved here, including the test names and how we organize them, but this seems like a decent start.

This also surfaced some issues with error types:
- when used to verify a commit (rather than just checking if we can skip), `voting_power_in` can't detect signatures from validators not in the current validator set
- we should have two distinct errors for InsufficientVotingPower - one when it's insufficient to skip, and one when it's insufficient to verify! Otherwise we might start bisecting when really the commit is just invalid ...

For now we're just duplicating some of the mocks that are already in the `verifier` tests module. Probably `verifier.rs` and `public.rs` will be consolidated down to `verifier` in #114 and this will be deduplicated then.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGES.md
