### PR TITLE
Remove `extern crate` directives

### DIFF
--- a/tendermint/src/amino_types/block_id.rs
+++ b/tendermint/src/amino_types/block_id.rs
@@ -6,6 +6,7 @@ use crate::{
     hash,
     hash::{Hash, SHA256_HASH_SIZE},
 };
+use prost_amino_derive::Message;
 
 #[derive(Clone, PartialEq, Message)]
 pub struct BlockId {

--- a/tendermint/src/amino_types/ed25519.rs
+++ b/tendermint/src/amino_types/ed25519.rs
@@ -1,4 +1,5 @@
 use crate::public_key::PublicKey;
+use prost_amino_derive::Message;
 use signatory::ed25519::PUBLIC_KEY_SIZE;
 
 // Note:On the golang side this is generic in the sense that it could everything that implements
@@ -44,7 +45,7 @@ impl From<PublicKey> for PubKeyResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prost::Message;
+    use prost_amino::Message;
 
     #[test]
     fn test_empty_pubkey_msg() {

--- a/tendermint/src/amino_types/message.rs
+++ b/tendermint/src/amino_types/message.rs
@@ -1,7 +1,7 @@
 use prost_amino::encoding::encoded_len_varint;
 use std::convert::TryInto;
 
-/// Extend the original prost::Message trait with a few helper functions in order to
+/// Extend the original prost_amino::Message trait with a few helper functions in order to
 /// reduce boiler-plate code (and without modifying the prost-amino dependency).
 pub trait AminoMessage: prost_amino::Message {
     /// Directly amino encode a prost-amino message into a freshly created Vec<u8>.

--- a/tendermint/src/amino_types/ping.rs
+++ b/tendermint/src/amino_types/ping.rs
@@ -1,3 +1,5 @@
+use prost_amino_derive::Message;
+
 pub const AMINO_NAME: &str = "tendermint/remotesigner/PingRequest";
 
 #[derive(Clone, PartialEq, Message)]

--- a/tendermint/src/amino_types/proposal.rs
+++ b/tendermint/src/amino_types/proposal.rs
@@ -11,7 +11,8 @@ use crate::{
     error::Error,
 };
 use bytes::BufMut;
-use prost::{EncodeError, Message};
+use prost_amino::{EncodeError, Message};
+use prost_amino_derive::Message;
 use signatory::ed25519;
 use std::convert::TryFrom;
 
@@ -194,7 +195,7 @@ mod tests {
     use super::*;
     use crate::amino_types::block_id::PartsSetHeader;
     use chrono::{DateTime, Utc};
-    use prost::Message;
+    use prost_amino::Message;
 
     #[test]
     fn test_serialization() {

--- a/tendermint/src/amino_types/remote_error.rs
+++ b/tendermint/src/amino_types/remote_error.rs
@@ -1,3 +1,5 @@
+use prost_amino_derive::Message;
+
 #[derive(Clone, PartialEq, Message)]
 pub struct RemoteError {
     #[prost_amino(sint32, tag = "1")]

--- a/tendermint/src/amino_types/signature.rs
+++ b/tendermint/src/amino_types/signature.rs
@@ -1,7 +1,7 @@
 use super::validate::ValidationError;
 use crate::{chain, consensus};
 use bytes::BufMut;
-use prost::{DecodeError, EncodeError};
+use prost_amino::{DecodeError, EncodeError};
 use signatory::ed25519;
 
 /// Amino messages which are signable within a Tendermint network

--- a/tendermint/src/amino_types/time.rs
+++ b/tendermint/src/amino_types/time.rs
@@ -5,6 +5,7 @@ use crate::{
     time::{ParseTimestamp, Time},
 };
 use chrono::{TimeZone, Utc};
+use prost_amino_derive::Message;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Clone, PartialEq, Message)]

--- a/tendermint/src/amino_types/version.rs
+++ b/tendermint/src/amino_types/version.rs
@@ -1,4 +1,5 @@
 use crate::block::*;
+use prost_amino_derive::Message;
 
 #[derive(Clone, Message)]
 pub struct ConsensusVersion {

--- a/tendermint/src/amino_types/vote.rs
+++ b/tendermint/src/amino_types/vote.rs
@@ -14,7 +14,8 @@ use crate::{
     vote,
 };
 use bytes::BufMut;
-use prost::{error::EncodeError, Message};
+use prost_amino::{error::EncodeError, Message};
+use prost_amino_derive::Message;
 use signatory::ed25519;
 use std::convert::TryFrom;
 

--- a/tendermint/src/error.rs
+++ b/tendermint/src/error.rs
@@ -5,7 +5,7 @@ use std::{
     fmt::{self, Display},
     io,
 };
-use {chrono, prost, subtle_encoding};
+use {chrono, prost_amino, subtle_encoding};
 
 /// Create a new error (of a given kind) with a formatted message
 #[allow(unused_macros)]
@@ -89,14 +89,14 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<prost::DecodeError> for Error {
-    fn from(err: prost::DecodeError) -> Self {
+impl From<prost_amino::DecodeError> for Error {
+    fn from(err: prost_amino::DecodeError) -> Self {
         err!(ErrorKind::Parse, err)
     }
 }
 
-impl From<prost::EncodeError> for Error {
-    fn from(err: prost::EncodeError) -> Self {
+impl From<prost_amino::EncodeError> for Error {
+    fn from(err: prost_amino::EncodeError) -> Self {
         err!(ErrorKind::Parse, err)
     }
 }

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -18,15 +18,6 @@
     html_root_url = "https://docs.rs/tendermint/0.11.0"
 )]
 
-// NOTE(EB): can't figure out how to easily remove the extern crate per Rust2018 upgrade ...
-#[allow(unused_extern_crates)]
-extern crate prost_amino as prost;
-
-// NOTE(EB): can't figure out how to easily remove the extern crate per Rust2018 upgrade ...
-#[allow(unused_extern_crates)]
-#[macro_use]
-extern crate prost_amino_derive as prost_derive;
-
 #[macro_use]
 pub mod error;
 

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -1,5 +1,6 @@
 //! Tendermint validators
 
+use prost_amino_derive::Message;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use signatory::{
     ed25519,


### PR DESCRIPTION
They were used as a hack around an old version of `prost`.

Now that `amino_rs` is properly namespaced, we don't need them.