### PR TITLE
Release/v0.12.0-rc0

### DIFF
--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.11.0" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.12.0-rc0" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/interchainio/tendermint-rs/tree/master/tendermint"

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -15,7 +15,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/kms/master/img/tendermint.png",
-    html_root_url = "https://docs.rs/tendermint/0.11.0"
+    html_root_url = "https://docs.rs/tendermint/0.12.0-rc0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
RC0 release mainly to get the #126 changes in the KMS, allowing for side-by-side usage with upstream `prost`, which will unblock using gRPC instead of Secret Connection + Amino for https://github.com/tendermint/kms/issues/386.

@ebuchman would be good to cut a real release after this, ideally before we do another KMS release, but this is a much-needed update to get rid of the last of the pre-`async`/`await` crates.