### PR TITLE
Move Amino type prefixes over from KMS

### DIFF
--- a/tendermint-lite/src/main.rs
+++ b/tendermint-lite/src/main.rs
@@ -99,7 +99,7 @@ fn main() {
  * trusted state and store it in the store ...
  * TODO: this should take traits ... but how to deal with the State ?
  * TODO: better name ?
-*/
+ */
 fn subjective_init(
     height: Height,
     vals_hash: Hash,

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -37,6 +37,7 @@ failure = "0.1"
 getrandom = "0.1"
 http = "0.2"
 hyper = "0.13"
+once_cell = "1.3"
 prost-amino = "0.5"
 prost-amino-derive = "0.5"
 serde = { version = "1", features = ["derive"] }

--- a/tendermint/src/amino_types.rs
+++ b/tendermint/src/amino_types.rs
@@ -17,13 +17,40 @@ pub mod vote;
 
 pub use self::{
     block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader, PartsSetHeader},
-    ed25519::{PubKeyRequest, PubKeyResponse, AMINO_NAME as PUBKEY_AMINO_NAME},
-    ping::{PingRequest, PingResponse, AMINO_NAME as PING_AMINO_NAME},
-    proposal::{SignProposalRequest, SignedProposalResponse, AMINO_NAME as PROPOSAL_AMINO_NAME},
+    ed25519::{
+        PubKeyRequest, PubKeyResponse, AMINO_NAME as PUBKEY_AMINO_NAME,
+        AMINO_PREFIX as PUBKEY_PREFIX,
+    },
+    ping::{PingRequest, PingResponse, AMINO_NAME as PING_AMINO_NAME, AMINO_PREFIX as PING_PREFIX},
+    proposal::{
+        SignProposalRequest, SignedProposalResponse, AMINO_NAME as PROPOSAL_AMINO_NAME,
+        AMINO_PREFIX as PROPOSAL_PREFIX,
+    },
     remote_error::RemoteError,
     signature::{SignableMsg, SignedMsgType},
     time::TimeMsg,
     validate::ConsensusMessage,
     version::ConsensusVersion,
-    vote::{SignVoteRequest, SignedVoteResponse, AMINO_NAME as VOTE_AMINO_NAME},
+    vote::{
+        SignVoteRequest, SignedVoteResponse, AMINO_NAME as VOTE_AMINO_NAME,
+        AMINO_PREFIX as VOTE_PREFIX,
+    },
 };
+
+use sha2::{Digest, Sha256};
+
+/// Compute the Amino prefix for the given registered type name
+pub fn compute_prefix(name: &str) -> Vec<u8> {
+    let mut sh = Sha256::default();
+    sh.input(name.as_bytes());
+    let output = sh.result();
+
+    output
+        .iter()
+        .filter(|&x| *x != 0x00)
+        .skip(3)
+        .filter(|&x| *x != 0x00)
+        .cloned()
+        .take(4)
+        .collect()
+}

--- a/tendermint/src/amino_types/ed25519.rs
+++ b/tendermint/src/amino_types/ed25519.rs
@@ -1,4 +1,6 @@
+use super::compute_prefix;
 use crate::public_key::PublicKey;
+use once_cell::sync::Lazy;
 use prost_amino_derive::Message;
 use signatory::ed25519::PUBLIC_KEY_SIZE;
 
@@ -9,6 +11,7 @@ use signatory::ed25519::PUBLIC_KEY_SIZE;
 // TODO(ismail): make this more generic (by modifying prost and adding a trait for PubKey)
 
 pub const AMINO_NAME: &str = "tendermint/remotesigner/PubKeyRequest";
+pub static AMINO_PREFIX: Lazy<Vec<u8>> = Lazy::new(|| compute_prefix(AMINO_NAME));
 
 #[derive(Clone, PartialEq, Message)]
 #[amino_name = "tendermint/remotesigner/PubKeyResponse"]

--- a/tendermint/src/amino_types/ping.rs
+++ b/tendermint/src/amino_types/ping.rs
@@ -1,6 +1,9 @@
+use super::compute_prefix;
+use once_cell::sync::Lazy;
 use prost_amino_derive::Message;
 
 pub const AMINO_NAME: &str = "tendermint/remotesigner/PingRequest";
+pub static AMINO_PREFIX: Lazy<Vec<u8>> = Lazy::new(|| compute_prefix(AMINO_NAME));
 
 #[derive(Clone, PartialEq, Message)]
 #[amino_name = "tendermint/remotesigner/PingRequest"]

--- a/tendermint/src/amino_types/proposal.rs
+++ b/tendermint/src/amino_types/proposal.rs
@@ -1,5 +1,6 @@
 use super::{
     block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader},
+    compute_prefix,
     remote_error::RemoteError,
     signature::{SignableMsg, SignedMsgType},
     time::TimeMsg,
@@ -11,6 +12,7 @@ use crate::{
     error::Error,
 };
 use bytes::BufMut;
+use once_cell::sync::Lazy;
 use prost_amino::{EncodeError, Message};
 use prost_amino_derive::Message;
 use signatory::ed25519;
@@ -42,6 +44,7 @@ impl block::ParseHeight for Proposal {
 }
 
 pub const AMINO_NAME: &str = "tendermint/remotesigner/SignProposalRequest";
+pub static AMINO_PREFIX: Lazy<Vec<u8>> = Lazy::new(|| compute_prefix(AMINO_NAME));
 
 #[derive(Clone, PartialEq, Message)]
 #[amino_name = "tendermint/remotesigner/SignProposalRequest"]

--- a/tendermint/src/amino_types/vote.rs
+++ b/tendermint/src/amino_types/vote.rs
@@ -1,5 +1,6 @@
 use super::{
     block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader},
+    compute_prefix,
     remote_error::RemoteError,
     signature::SignableMsg,
     time::TimeMsg,
@@ -14,6 +15,7 @@ use crate::{
     vote,
 };
 use bytes::BufMut;
+use once_cell::sync::Lazy;
 use prost_amino::{error::EncodeError, Message};
 use prost_amino_derive::Message;
 use signatory::ed25519;
@@ -78,6 +80,7 @@ impl block::ParseHeight for Vote {
 }
 
 pub const AMINO_NAME: &str = "tendermint/remotesigner/SignVoteRequest";
+pub static AMINO_PREFIX: Lazy<Vec<u8>> = Lazy::new(|| compute_prefix(AMINO_NAME));
 
 #[derive(Clone, PartialEq, Message)]
 #[amino_name = "tendermint/remotesigner/SignVoteRequest"]


### PR DESCRIPTION
I'd like to compute some Amino type prefixes in something other than the KMS (namely an oracle feeder) and unfortunately the code to do so is presently vendored into the KMS, and used to compute these prefixes (with a TODO to move it elsewhere):

https://github.com/tendermint/kms/blob/master/src/rpc.rs#L45

It seems like these should go with the Amino types. Perhaps the `compute_prefix` method should be moved into the `amino_rs` crate.