### PR TITLE
Light errors: Remove `InvalidSignature` and `InvalidCommitSignatures` 

### DIFF
--- a/tendermint-lite/src/main.rs
+++ b/tendermint-lite/src/main.rs
@@ -9,7 +9,7 @@ use tendermint_lite::{requester::RPCRequester, store::MemStore};
 
 use core::future::Future;
 use std::time::{Duration, SystemTime};
-use tendermint::lite::error::Kind;
+use tendermint::lite::error::Error;
 use tendermint_lite::store::State;
 use tokio::runtime::Builder;
 
@@ -102,7 +102,7 @@ fn subjective_init(
     vals_hash: Hash,
     store: &mut MemStore,
     req: &RPCRequester,
-) -> Result<(), Kind> {
+) -> Result<(), Error> {
     if store.get(height.value()).is_ok() {
         // we already have this !
         return Ok(());

--- a/tendermint-lite/src/requester.rs
+++ b/tendermint-lite/src/requester.rs
@@ -26,7 +26,7 @@ impl lite::types::Requester<TMCommit, TMHeader> for RPCRequester {
     /// Request the signed header at height h.
     /// If h==0, request the latest signed header.
     /// TODO: use an enum instead of h==0.
-    fn signed_header(&self, h: Height) -> Result<TMSignedHeader, error::Kind> {
+    fn signed_header(&self, h: Height) -> Result<TMSignedHeader, error::Error> {
         let height: block::Height = h.into();
         let r = match height.value() {
             0 => block_on(self.client.latest_commit()),
@@ -34,16 +34,16 @@ impl lite::types::Requester<TMCommit, TMHeader> for RPCRequester {
         };
         match r {
             Ok(response) => Ok(response.signed_header.into()),
-            Err(error) => Err(error::Kind::RequestFailed(format!("{:?}", error))),
+            Err(error) => Err(error::Kind::RequestFailed.context(error).into()),
         }
     }
 
     /// Request the validator set at height h.
-    fn validator_set(&self, h: Height) -> Result<Set, error::Kind> {
+    fn validator_set(&self, h: Height) -> Result<Set, error::Error> {
         let r = block_on(self.client.validators(h));
         match r {
             Ok(response) => Ok(validator::Set::new(response.validators)),
-            Err(error) => Err(error::Kind::RequestFailed(format!("{:?}", error))),
+            Err(error) => Err(error::Kind::RequestFailed.context(error).into()),
         }
     }
 }

--- a/tendermint-lite/src/store.rs
+++ b/tendermint-lite/src/store.rs
@@ -2,7 +2,7 @@ use tendermint::lite::{Header, Height, TrustedState};
 
 use std::collections::HashMap;
 use tendermint::block;
-use tendermint::lite::error::Kind;
+use tendermint::lite::error::{Error, Kind};
 
 pub type State = TrustedState<block::signed_header::SignedHeader, block::header::Header>;
 
@@ -22,24 +22,23 @@ impl MemStore {
 }
 
 impl MemStore {
-    pub fn add(&mut self, trusted: State) -> Result<(), Kind> {
+    pub fn add(&mut self, trusted: State) -> Result<(), Error> {
         let height = trusted.last_header().header().height();
         self.height = height;
         self.store.insert(height, trusted);
         Ok(())
     }
 
-    pub fn get(&self, h: Height) -> Result<&State, Kind> {
+    pub fn get(&self, h: Height) -> Result<&State, Error> {
         let mut height = h;
         if h == 0 {
             height = self.height
         }
         match self.store.get(&height) {
             Some(state) => Ok(state),
-            None => Err(Kind::RequestFailed(format!(
-                "could not load height {} from strore",
-                height
-            ))),
+            None => Err(Kind::RequestFailed
+                .context(format!("could not load height {} from store", height))
+                .into()),
         }
     }
 }

--- a/tendermint/src/lite/error.rs
+++ b/tendermint/src/lite/error.rs
@@ -58,8 +58,8 @@ pub enum Kind {
     #[error("A valid threshold is `1/3 <= threshold <= 1`, got: {got}")]
     InvalidTrustThreshold { got: String },
 
-    #[error("Implementation specific error: {0}")]
-    ImplementationSpecific(String),
+    #[error("Implementation specific error")]
+    ImplementationSpecific,
 }
 
 impl Kind {

--- a/tendermint/src/lite/error.rs
+++ b/tendermint/src/lite/error.rs
@@ -38,7 +38,7 @@ pub enum Kind {
         next_val_hash: Hash,
     },
 
-    /// commit is not for the header we expected.
+    /// Commit is not for the header we expected.
     #[error(
         "header hash does not match the hash in the commit ({header_hash:?}!={commit_hash:?})"
     )]

--- a/tendermint/src/lite/error.rs
+++ b/tendermint/src/lite/error.rs
@@ -20,9 +20,6 @@ pub enum Kind {
     #[error("expected height >= {expected} (got: {got})")]
     NonIncreasingHeight { got: u64, expected: u64 },
 
-    #[error("could not verify signature")]
-    InvalidSignature, // TODO: deduplicate with tendermint::ErrorKind::SignatureInvalid
-
     #[error("header's validator hash does not match actual validator hash ({header_val_hash:?}!={val_hash:?})")]
     InvalidValidatorSet {
         header_val_hash: Hash,
@@ -43,9 +40,6 @@ pub enum Kind {
         commit_hash: Hash,
     }, // commit is not for the header we expected
 
-    #[error("error validating commit signatures: {info}")]
-    InvalidCommitSignatures { info: String }, // Note: this is only used by implementation (ie. expected return in Commit::validate())
-
     #[error("signed voting power ({signed}) do not account for +2/3 of the total voting power: ({total})")]
     InvalidCommit { total: u64, signed: u64 },
 
@@ -63,6 +57,9 @@ pub enum Kind {
 
     #[error("A valid threshold is `1/3 <= threshold <= 1`, got: {got}")]
     InvalidTrustThreshold { got: String },
+
+    #[error("Implementation specific error: {0}")]
+    ImplementationSpecific(String),
 }
 
 impl Kind {

--- a/tendermint/src/lite/types.rs
+++ b/tendermint/src/lite/types.rs
@@ -126,10 +126,10 @@ where
     H: Header,
 {
     /// Request the [`SignedHeader`] at height h.
-    fn signed_header(&self, h: Height) -> Result<SignedHeader<C, H>, Kind>;
+    fn signed_header(&self, h: Height) -> Result<SignedHeader<C, H>, Error>;
 
     /// Request the validator set at height h.
-    fn validator_set(&self, h: Height) -> Result<C::ValidatorSet, Kind>;
+    fn validator_set(&self, h: Height) -> Result<C::ValidatorSet, Error>;
 }
 
 /// TrustedState contains a state trusted by a lite client,
@@ -336,25 +336,26 @@ pub(super) mod mocks {
         }
     }
     impl Requester<MockCommit, MockHeader> for MockRequester {
-        fn signed_header(&self, h: u64) -> Result<SignedHeader<MockCommit, MockHeader>, Kind> {
+        fn signed_header(&self, h: u64) -> Result<SignedHeader<MockCommit, MockHeader>, Error> {
             println!("requested signed header for height:{:?}", h);
             if let Some(sh) = self.signed_headers.get(&h) {
                 return Ok(sh.to_owned());
             }
             println!("couldn't get sh for: {}", &h);
-            Err(Kind::RequestFailed(format!("couldn't get sh for: {}", &h)))
+            Err(Kind::RequestFailed
+                .context(format!("couldn't get sh for: {}", &h))
+                .into())
         }
 
-        fn validator_set(&self, h: u64) -> Result<MockValSet, Kind> {
+        fn validator_set(&self, h: u64) -> Result<MockValSet, Error> {
             println!("requested validators for height:{:?}", h);
             if let Some(vs) = self.validators.get(&h) {
                 return Ok(vs.to_owned());
             }
             println!("couldn't get vals for: {}", &h);
-            Err(Kind::RequestFailed(format!(
-                "couldn't get vals for: {}",
-                &h
-            )))
+            Err(Kind::RequestFailed
+                .context(format!("couldn't get vals for: {}", &h))
+                .into())
         }
     }
 

--- a/tendermint/src/lite/types.rs
+++ b/tendermint/src/lite/types.rs
@@ -311,9 +311,9 @@ pub(super) mod mocks {
         fn validate(&self, _vals: &Self::ValidatorSet) -> Result<(), Error> {
             // some implementation specific checks:
             if self.vals.is_empty() || self.hash.algorithm() != Algorithm::Sha256 {
-                return Err(Kind::InvalidCommitSignatures {
-                    info: "validator set is empty, or, invalid hash algo".to_string(),
-                }
+                return Err(Kind::ImplementationSpecific(
+                    "validator set is empty, or, invalid hash algo".to_string(),
+                )
                 .into());
             }
             Ok(())

--- a/tendermint/src/lite/types.rs
+++ b/tendermint/src/lite/types.rs
@@ -311,10 +311,9 @@ pub(super) mod mocks {
         fn validate(&self, _vals: &Self::ValidatorSet) -> Result<(), Error> {
             // some implementation specific checks:
             if self.vals.is_empty() || self.hash.algorithm() != Algorithm::Sha256 {
-                return Err(Kind::ImplementationSpecific(
-                    "validator set is empty, or, invalid hash algo".to_string(),
-                )
-                .into());
+                return Err(Kind::ImplementationSpecific
+                    .context("validator set is empty, or, invalid hash algo".to_string())
+                    .into());
             }
             Ok(())
         }

--- a/tendermint/src/lite_impl/signed_header.rs
+++ b/tendermint/src/lite_impl/signed_header.rs
@@ -35,12 +35,13 @@ impl lite::Commit for block::signed_header::SignedHeader {
             let sign_bytes = vote.sign_bytes();
 
             if !val.verify_signature(&sign_bytes, vote.signature()) {
-                return Err(Kind::ImplementationSpecific(format!(
-                    "Couldn't verify signature {:?} with validator {:?}",
-                    vote.signature(),
-                    val
-                ))
-                .into());
+                return Err(Kind::ImplementationSpecific
+                    .context(format!(
+                        "Couldn't verify signature {:?} with validator {:?}",
+                        vote.signature(),
+                        val
+                    ))
+                    .into());
             }
             signed_power += val.power();
         }
@@ -50,12 +51,13 @@ impl lite::Commit for block::signed_header::SignedHeader {
 
     fn validate(&self, vals: &Self::ValidatorSet) -> Result<(), Error> {
         if self.commit.precommits.len() != vals.validators().len() {
-            return Err(lite::error::Kind::ImplementationSpecific(format!(
-                "pre-commit length: {} doesn't match validator length: {}",
-                self.commit.precommits.len(),
-                vals.validators().len()
-            ))
-            .into());
+            return Err(lite::error::Kind::ImplementationSpecific
+                .context(format!(
+                    "pre-commit length: {} doesn't match validator length: {}",
+                    self.commit.precommits.len(),
+                    vals.validators().len()
+                ))
+                .into());
         }
         // TODO: compare to the go code for more implementation related checks and clarify if this:
         // https://github.com/interchainio/tendermint-rs/pull/143/commits/0a30022fa47e909e6c7b20417dd178c8a3b84838#r374958528

--- a/tendermint/src/lite_impl/signed_header.rs
+++ b/tendermint/src/lite_impl/signed_header.rs
@@ -37,9 +37,10 @@ impl lite::Commit for block::signed_header::SignedHeader {
             if !val.verify_signature(&sign_bytes, vote.signature()) {
                 return Err(Kind::ImplementationSpecific
                     .context(format!(
-                        "Couldn't verify signature {:?} with validator {:?}",
+                        "Couldn't verify signature {:?} with validator {:?} on sign_bytes {:?}",
                         vote.signature(),
-                        val
+                        val,
+                        sign_bytes,
                     ))
                     .into());
             }

--- a/tendermint/src/lite_impl/signed_header.rs
+++ b/tendermint/src/lite_impl/signed_header.rs
@@ -35,7 +35,12 @@ impl lite::Commit for block::signed_header::SignedHeader {
             let sign_bytes = vote.sign_bytes();
 
             if !val.verify_signature(&sign_bytes, vote.signature()) {
-                return Err(Kind::InvalidSignature.into());
+                return Err(Kind::ImplementationSpecific(format!(
+                    "Couldn't verify signature {:?} with validator {:?}",
+                    vote.signature(),
+                    val
+                ))
+                .into());
             }
             signed_power += val.power();
         }
@@ -45,13 +50,11 @@ impl lite::Commit for block::signed_header::SignedHeader {
 
     fn validate(&self, vals: &Self::ValidatorSet) -> Result<(), Error> {
         if self.commit.precommits.len() != vals.validators().len() {
-            return Err(lite::error::Kind::InvalidCommitSignatures {
-                info: format!(
-                    "pre-commit length: {} doesn't match validator length: {}",
-                    self.commit.precommits.len(),
-                    vals.validators().len()
-                ),
-            }
+            return Err(lite::error::Kind::ImplementationSpecific(format!(
+                "pre-commit length: {} doesn't match validator length: {}",
+                self.commit.precommits.len(),
+                vals.validators().len()
+            ))
             .into());
         }
         // TODO: compare to the go code for more implementation related checks and clarify if this:

--- a/tendermint/src/rpc/error.rs
+++ b/tendermint/src/rpc/error.rs
@@ -16,6 +16,7 @@ pub struct Error {
     /// Additional data about the error
     data: Option<String>,
 }
+impl std::error::Error for Error {}
 
 impl Error {
     /// Create a new RPC error
@@ -92,12 +93,6 @@ impl Display for Error {
             ),
             None => write!(f, "{} (code: {})", self.message, self.code.value()),
         }
-    }
-}
-
-impl Fail for Error {
-    fn name(&self) -> Option<&str> {
-        self.code.name()
     }
 }
 


### PR DESCRIPTION
Followup to #149:
- remove `InvalidSignature` and `InvalidCommitSignatures`
- introduce `ImplementationSpecific` Kind instead
- simplify `RequestFailed` in the same way


closes #149 
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
