### PR TITLE
rpc: remove usage of deprecated method in client

### DIFF
--- a/tendermint/src/rpc/client.rs
+++ b/tendermint/src/rpc/client.rs
@@ -187,7 +187,7 @@ impl Client {
             );
         }
 
-        let http_client = hyper::Client::builder().keep_alive(true).build_http();
+        let http_client = hyper::Client::builder().build_http();
         let response = http_client.request(request).await?;
         let response_body = hyper::body::aggregate(response.into_body()).await?;
         R::Response::from_reader(response_body.reader())


### PR DESCRIPTION
One-liner that fixes the build again.

I've verified that this change doesn't modify the current logic/init. See https://github.com/hyperium/hyper/pull/2142/files for yourself in case you have doubts.

ref https://circleci.com/gh/interchainio/tendermint-rs/1202
closes #165 

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md
