### PR TITLE
Turn `rpc::Client::new` into a sync fn by not performing the health check on creation

### DIFF
--- a/tendermint-lite/src/main.rs
+++ b/tendermint-lite/src/main.rs
@@ -33,7 +33,13 @@ fn main() {
     let trusting_period = Duration::new(6000, 0);
 
     // setup requester for primary peer
-    let client = block_on(rpc::Client::new_healthy(RPC_ADDR.parse().unwrap())).unwrap();
+    let client = rpc::Client::new(RPC_ADDR.parse().unwrap());
+
+    if let Err(err) = block_on(client.health()) {
+        eprintln!("error: health check failed: {}", err);
+        std::process::exit(1);
+    }
+
     let req = RPCRequester::new(client);
     let mut store = MemStore::new();
 

--- a/tendermint-lite/src/main.rs
+++ b/tendermint-lite/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
     let trusting_period = Duration::new(6000, 0);
 
     // setup requester for primary peer
-    let client = block_on(rpc::Client::new(&RPC_ADDR.parse().unwrap())).unwrap();
+    let client = block_on(rpc::Client::new_healthy(RPC_ADDR.parse().unwrap())).unwrap();
     let req = RPCRequester::new(client);
     let mut store = MemStore::new();
 

--- a/tendermint-lite/src/requester.rs
+++ b/tendermint-lite/src/requester.rs
@@ -69,7 +69,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_val_set() {
-        let client = block_on(rpc::Client::new(&"localhost:26657".parse().unwrap())).unwrap();
+        let client = rpc::Client::new("localhost:26657".parse().unwrap());
         let req = RPCRequester::new(client);
         let r1 = req.validator_set(5).unwrap();
         let r2 = req.signed_header(5).unwrap();

--- a/tendermint/src/rpc/client.rs
+++ b/tendermint/src/rpc/client.rs
@@ -20,10 +20,14 @@ pub struct Client {
 
 impl Client {
     /// Create a new Tendermint RPC client, connecting to the given address
-    pub async fn new(address: &net::Address) -> Result<Self, Error> {
-        let client = Client {
-            address: address.clone(),
-        };
+    pub fn new(address: net::Address) -> Self {
+        Self { address }
+    }
+
+    /// Create a new Tendermint RPC client, connecting to the given address,
+    /// and perform a health check.
+    pub async fn new_healthy(address: net::Address) -> Result<Self, Error> {
+        let client = Self::new(address);
         client.health().await?;
         Ok(client)
     }

--- a/tendermint/src/rpc/client.rs
+++ b/tendermint/src/rpc/client.rs
@@ -24,14 +24,6 @@ impl Client {
         Self { address }
     }
 
-    /// Create a new Tendermint RPC client, connecting to the given address,
-    /// and perform a health check.
-    pub async fn new_healthy(address: net::Address) -> Result<Self, Error> {
-        let client = Self::new(address);
-        client.health().await?;
-        Ok(client)
-    }
-
     /// `/abci_info`: get information about the ABCI application.
     pub async fn abci_info(&self) -> Result<abci_info::AbciInfo, Error> {
         Ok(self.perform(abci_info::Request).await?.response)

--- a/tendermint/tests/integration.rs
+++ b/tendermint/tests/integration.rs
@@ -24,7 +24,15 @@ mod rpc {
 
     /// Get the address of the local node
     pub fn localhost_rpc_client() -> Client {
-        block_on(Client::new(&"tcp://127.0.0.1:26657".parse().unwrap())).unwrap()
+        Client::new("tcp://127.0.0.1:26657".parse().unwrap())
+    }
+
+    /// `/health` endpoint
+    #[test]
+    #[ignore]
+    fn health() {
+        let result = block_on(localhost_rpc_client().health());
+        assert!(result.is_ok(), "health check failed");
     }
 
     /// `/abci_info` endpoint


### PR DESCRIPTION
See #168 for the rationale behind this change.

In addition, both methods now take ownership of the `rpc::Address` rather than cloning a reference. This avoids unnecessary clones when the caller already has ownership of the address.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGES.md
