### PR TITLE
Turn `lite::types::Requester` into an async trait

### DIFF
--- a/tendermint-lite/Cargo.toml
+++ b/tendermint-lite/Cargo.toml
@@ -8,4 +8,6 @@ edition = "2018"
 
 [dependencies]
 tendermint = { path = "../tendermint" }
-tokio = "0.2"
+
+async-trait = "0.1"
+tokio = { version = "0.2", features = ["full"] }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -31,10 +31,11 @@ all-features = true
 circle-ci = { repository = "interchainio/tendermint-rs" }
 
 [dependencies]
+anomaly = "0.2"
+async-trait = "0.1"
 bytes = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
-anomaly = "0.2"
-thiserror = "1"
+futures = "0.3"
 getrandom = "0.1"
 http = "0.2"
 hyper = "0.13"
@@ -43,13 +44,14 @@ prost-amino = "0.5"
 prost-amino-derive = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
+sha2 = { version = "0.8", default-features = false }
 signatory = { version = "0.18", features = ["ed25519", "ecdsa"] }
 signatory-dalek = "0.18"
 signatory-secp256k1 = "0.18"
-sha2 = { version = "0.8", default-features = false }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tai64 = { version = "3", features = ["chrono"] }
+thiserror = "1"
 toml = { version = "0.5" }
 uuid = { version = "0.8", default-features = false }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

Closes: #170

On top of the changes mentioned in the linked issue, `lite::verifier::verify_bisection_inner` had to be manually adapted to return a boxed future because recursive async fn are not currently supported in Rust.

An possible alternative would be to rewrite `verify_bisection_inner` to not be recursive anymore, but that is outside of the scope of this PR.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGES.md